### PR TITLE
Better ways to deal with nil

### DIFF
--- a/tetrominos/tetrominos.cr
+++ b/tetrominos/tetrominos.cr
@@ -159,19 +159,19 @@ class Field
   
   def step
     @clock.restart
-    if !@part
-      @part = Part.new(self)
-      if @part.not_nil!.collides?
-        @over = true
-      end
-    else
-      if @part.not_nil!.down
-        @part.not_nil!.each_with_pos do |b, x, y|
+    if part = @part
+      if part.down
+        part.each_with_pos do |b, x, y|
           @body[y][x] = b if b
         end
         @part = nil
         lines
         step
+      end
+    else
+      part = @part = Part.new(self)
+      if part.collides?
+        @over = true
       end
     end
     true
@@ -184,9 +184,7 @@ class Field
       rect.position = SF.vector2f(x, y)
       target.draw(rect, states)
     end
-    if @part
-      @part.not_nil!.draw(target, states)
-    end
+    @part.try &.draw(target, states)
   end
   
   def lines


### PR DESCRIPTION
Two things:
- The compiler tracks the type of local variables only. So I assign instance variables to local varaibles instead of doing `not_nil!`. This has the added benefit that a nil check is only done once.
- You can use the `try` method to invoke a method on a nilable object only if it's not nil. Using the short-block notation it's even easier.
